### PR TITLE
Update snowflake generator with relationships path

### DIFF
--- a/oddrn_generator/path_models.py
+++ b/oddrn_generator/path_models.py
@@ -130,6 +130,7 @@ class SnowflakePathsModel(BasePathsModel):
     tables_columns: Optional[str] = Field(alias="columns")
     views_columns: Optional[str] = Field(alias="columns")
     pipes: Optional[str]
+    relationships: Optional[str]
 
     class Config:
         dependencies_map = {
@@ -140,6 +141,7 @@ class SnowflakePathsModel(BasePathsModel):
             "tables_columns": ("databases", "schemas", "tables", "tables_columns"),
             "views_columns": ("databases", "schemas", "views", "views_columns"),
             "pipes": ("pipes",),
+            "relationships": ("databases", "schemas", "tables", "relationships"),
         }
         data_source_path = "databases"
 

--- a/tests/params.py
+++ b/tests/params.py
@@ -75,6 +75,7 @@ parameters_host = [
                 "tables_columns": "some_table_column",
                 "views_columns": "some_view_column",
                 "pipes": "pipe",
+                "relationships": "some_relationship",
             },
             "aliases": {
                 "tables_columns": "columns",


### PR DESCRIPTION
Adds a `relationships` path to the `SnowflakePathsModel`.

Example of oddrn for relationship: `table_1` references `table_2` with  `constraint_fk`:
`//snowflake/host/hostname.snowflake/databases/database_name/schemas/schema_name/tables/table_1/relationships/references_table_2_with_constraint_fk`