### PR TITLE
Update Snowflake paths models for pipes

### DIFF
--- a/oddrn_generator/path_models.py
+++ b/oddrn_generator/path_models.py
@@ -172,7 +172,7 @@ class SnowflakePathsModel(BasePathsModel):
             "views": ("databases", "schemas", "views"),
             "tables_columns": ("databases", "schemas", "tables", "tables_columns"),
             "views_columns": ("databases", "schemas", "views", "views_columns"),
-            "pipes": ("pipes",),
+            "pipes": ("databases", "schemas", "pipes"),
             "relationships": ("databases", "schemas", "tables", "relationships"),
         }
 


### PR DESCRIPTION
Old pipe oddrn generation strategy: `//snowflake/host/XXXXXXX-YYYYYYY.snowflakecomputing.com/pipes/<pipe_name>`
New pipe oddrn generation strategy: `//snowflake/host/XXXXXXX-YYYYYYY.snowflakecomputing.com/databases/<database_name>/schemas/<schema_name>/pipes/<pipe_name>`

Benefits:
- possibility to attach pipe for the schema it belongs to;
- fix oddrn uniqueness issue for the case then pipes have the same name, but belong to different schemas (which is a valid case).